### PR TITLE
Implement --until CLI option

### DIFF
--- a/src/scrobbledb/lastfm.py
+++ b/src/scrobbledb/lastfm.py
@@ -58,7 +58,7 @@ def _api_request_with_retry(user: pylast.User, method: str, cacheable: bool = Tr
                 raise
 
 
-def recent_tracks_count(user: pylast.User, since: dt.datetime):
+def recent_tracks_count(user: pylast.User, since: dt.datetime, until: dt.datetime = None):
     """
     Return the number of tracks recorded since a given datetime.
 
@@ -66,10 +66,14 @@ def recent_tracks_count(user: pylast.User, since: dt.datetime):
     """
 
     logger.info("Checking for tracks since {}", since.isoformat() if since else None)
+    if until:
+        logger.info("Checking for tracks until {}", until.isoformat())
     try:
         params = dict(user._get_params(), limit=200)
         if since:
             params["from"] = int(since.timestamp())
+        if until:
+            params["to"] = int(until.timestamp())
         params["page"] = 1
         params["limit"] = 1
         doc = _api_request_with_retry(user, "user.getRecentTracks", cacheable=True, params=params)
@@ -126,7 +130,7 @@ def recent_tracks_count(user: pylast.User, since: dt.datetime):
         return 0
 
 
-def recent_tracks(user: pylast.User, since: dt.datetime, limit: int = None):
+def recent_tracks(user: pylast.User, since: dt.datetime, until: dt.datetime = None, limit: int = None):
     """
     This is similar to pylast.User.get_recent_tracks
     (https://github.com/pylast/pylast/blob/master/src/pylast/__init__.py#L2362),
@@ -153,6 +157,10 @@ def recent_tracks(user: pylast.User, since: dt.datetime, limit: int = None):
         logger.info(f"Fetching tracks since {since.isoformat()}")
     else:
         logger.info("Fetching all available tracks")
+
+    if until:
+        params["to"] = int(until.timestamp())
+        logger.info(f"Fetching tracks until {until.isoformat()}")
 
     if limit:
         logger.info(f"Limiting to {limit} tracks")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -282,6 +282,71 @@ class TestSinceDateIsofixFormat:
                     assert "Fetching scrobbles since:" in result.output
                     assert "2024-01-15" in result.output
 
+    def test_ingest_with_until_date(self, runner, temp_db, temp_auth):
+        """Test ingest with explicit --until-date flag.
+
+        Should display the provided until date in the output.
+        """
+        db_path, db = temp_db
+
+        mock_user = Mock()
+        mock_network = Mock()
+        mock_network.get_user.return_value = mock_user
+
+        with patch("scrobbledb.lastfm.get_network", return_value=mock_network):
+            with patch("scrobbledb.lastfm.recent_tracks_count", return_value=0):
+                with patch("scrobbledb.lastfm.recent_tracks", return_value=[]):
+                    result = runner.invoke(
+                        cli.cli,
+                        [
+                            "ingest",
+                            db_path,
+                            "-a",
+                            temp_auth,
+                            "--until-date",
+                            "2024-12-31",
+                            "--dry-run",
+                        ],
+                    )
+
+                    assert result.exit_code == 0, f"Command failed: {result.output}"
+                    assert "Fetching scrobbles until:" in result.output
+                    assert "2024-12-31" in result.output
+
+    def test_ingest_with_since_and_until_dates(self, runner, temp_db, temp_auth):
+        """Test ingest with both --since-date and --until-date flags.
+
+        Should display both dates in the output.
+        """
+        db_path, db = temp_db
+
+        mock_user = Mock()
+        mock_network = Mock()
+        mock_network.get_user.return_value = mock_user
+
+        with patch("scrobbledb.lastfm.get_network", return_value=mock_network):
+            with patch("scrobbledb.lastfm.recent_tracks_count", return_value=0):
+                with patch("scrobbledb.lastfm.recent_tracks", return_value=[]):
+                    result = runner.invoke(
+                        cli.cli,
+                        [
+                            "ingest",
+                            db_path,
+                            "-a",
+                            temp_auth,
+                            "--since-date",
+                            "2024-01-01",
+                            "--until-date",
+                            "2024-12-31",
+                            "--dry-run",
+                        ],
+                    )
+
+                    assert result.exit_code == 0, f"Command failed: {result.output}"
+                    assert "Fetching scrobbles from" in result.output
+                    assert "2024-01-01" in result.output
+                    assert "2024-12-31" in result.output
+
 
 class TestCombinedFixes:
     """Integration tests combining both fixes."""


### PR DESCRIPTION
Add --until-date option to the ingest command to allow users to specify an upper bound timestamp when ingesting scrobbles from Last.fm.

Changes:
- Add --until-date CLI option to ingest command
- Update recent_tracks_count() to accept and use until parameter
- Update recent_tracks() to accept and use until parameter
- Add console output showing the date range being fetched
- Add comprehensive tests for --until-date functionality

The --until-date option can be used alone or in combination with --since-date to specify a precise time range for data ingestion.

Fixes #30