### PR TITLE
Assign default commands to subgroups

### DIFF
--- a/docs/commands/albums.md
+++ b/docs/commands/albums.md
@@ -22,7 +22,7 @@ Options:
   --help  Show this message and exit.
 
 Commands:
-  list    List albums with optional artist filter.
+  list*   List albums with optional artist filter.
   search  Search for albums using fuzzy matching.
   show    Display detailed information about a specific album and list its...
   top     Show top albums with flexible time range support.

--- a/docs/commands/artists.md
+++ b/docs/commands/artists.md
@@ -22,7 +22,7 @@ Options:
   --help  Show this message and exit.
 
 Commands:
-  list    List all artists in the database with play statistics.
+  list*   List all artists in the database with play statistics.
   search  Search for artists using fuzzy matching.
   show    Display detailed information about a specific artist.
   top     Show top artists with flexible time range support.

--- a/docs/commands/plays.md
+++ b/docs/commands/plays.md
@@ -22,7 +22,7 @@ Options:
   --help  Show this message and exit.
 
 Commands:
-  list  List recent plays with filtering and pagination.
+  list*  List recent plays with filtering and pagination.
 ```
 <!-- [[[end]]] -->
 

--- a/docs/commands/stats.md
+++ b/docs/commands/stats.md
@@ -33,9 +33,9 @@ Options:
   --help  Show this message and exit.
 
 Commands:
-  monthly   Display scrobble statistics rolled up by month.
-  overview  Display overall scrobble statistics.
-  yearly    Display scrobble statistics rolled up by year.
+  overview*  Display overall scrobble statistics.
+  monthly    Display scrobble statistics rolled up by month.
+  yearly     Display scrobble statistics rolled up by year.
 ```
 <!-- [[[end]]] -->
 

--- a/docs/commands/tracks.md
+++ b/docs/commands/tracks.md
@@ -22,7 +22,7 @@ Options:
   --help  Show this message and exit.
 
 Commands:
-  list    List tracks with optional filters.
+  list*   List tracks with optional filters.
   search  Search for tracks using fuzzy matching.
   show    Display detailed information about a specific track.
   top     Show top tracks with flexible time range support.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "stamina>=24.2.0",
     "rapidfuzz>=3.0.0",
     "dateparser>=1.1.0",
+    "click-default-group>=1.2.4",
 ]
 
 [project.optional-dependencies]

--- a/src/scrobbledb/commands/albums.py
+++ b/src/scrobbledb/commands/albums.py
@@ -5,6 +5,7 @@ Commands for searching albums and viewing album details.
 """
 
 import click
+from click_default_group import DefaultGroup
 from rich.console import Console
 
 from ..command_utils import (
@@ -24,7 +25,7 @@ from .. import domain_format
 console = Console(stderr=True)
 
 
-@click.group()
+@click.group(cls=DefaultGroup, default="list", default_if_no_args=True)
 def albums():
     """
     Album investigation commands.

--- a/src/scrobbledb/commands/artists.py
+++ b/src/scrobbledb/commands/artists.py
@@ -5,6 +5,7 @@ Commands for listing artists, viewing top artists, and artist details.
 """
 
 import click
+from click_default_group import DefaultGroup
 from rich.console import Console
 
 from ..command_utils import (
@@ -23,7 +24,7 @@ from .. import domain_format
 console = Console(stderr=True)
 
 
-@click.group()
+@click.group(cls=DefaultGroup, default="list", default_if_no_args=True)
 def artists():
     """
     Artist investigation commands.

--- a/src/scrobbledb/commands/plays.py
+++ b/src/scrobbledb/commands/plays.py
@@ -5,6 +5,7 @@ Commands for viewing play history with filtering and pagination.
 """
 
 import click
+from click_default_group import DefaultGroup
 from rich.console import Console
 
 from ..command_utils import (
@@ -23,7 +24,7 @@ from .. import domain_format
 console = Console()
 
 
-@click.group()
+@click.group(cls=DefaultGroup, default="list", default_if_no_args=True)
 def plays():
     """
     Play history commands.

--- a/src/scrobbledb/commands/stats.py
+++ b/src/scrobbledb/commands/stats.py
@@ -8,6 +8,7 @@ This module provides CLI commands for viewing scrobble statistics:
 """
 
 import click
+from click_default_group import DefaultGroup
 from rich.console import Console
 
 from ..command_utils import (
@@ -33,7 +34,7 @@ from ..domain_format import (
 console = Console()
 
 
-@click.group()
+@click.group(cls=DefaultGroup, default="overview", default_if_no_args=True)
 def stats():
     """
     Descriptive statistics about your scrobbles.

--- a/src/scrobbledb/commands/tracks.py
+++ b/src/scrobbledb/commands/tracks.py
@@ -5,6 +5,7 @@ Commands for searching tracks, viewing top tracks, and track details.
 """
 
 import click
+from click_default_group import DefaultGroup
 from rich.console import Console
 
 from ..command_utils import (
@@ -24,7 +25,7 @@ from .. import domain_format
 console = Console(stderr=True)
 
 
-@click.group()
+@click.group(cls=DefaultGroup, default="list", default_if_no_args=True)
 def tracks():
     """
     Track investigation commands.

--- a/uv.lock
+++ b/uv.lock
@@ -1163,6 +1163,7 @@ version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
+    { name = "click-default-group" },
     { name = "dateparser" },
     { name = "loguru" },
     { name = "loguru-config" },
@@ -1198,6 +1199,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=7.0" },
+    { name = "click-default-group", specifier = ">=1.2.4" },
     { name = "cogapp", marker = "extra == 'dev'", specifier = ">=3.4.1" },
     { name = "dateparser", specifier = ">=1.1.0" },
     { name = "loguru", specifier = ">=0.7.3" },


### PR DESCRIPTION
## Summary
- Add `click-default-group` as a direct dependency (was previously only pulled in transitively)
- `albums`, `artists`, `plays`, and `tracks` now default to their `list` subcommand; `stats` defaults to `overview`, so e.g. `scrobbledb albums` behaves like `scrobbledb albums list`
- Regenerate cog-based CLI docs under `docs/commands/`

Closes #49

## Test plan
- [x] `uv run poe test:quick` — 222 passed
- [x] `uv run poe lint` — all checks passed
- [x] `uv run poe type` — all checks passed
- [x] Manually verified against a populated test database that `scrobbledb albums`, `artists`, `plays`, `tracks`, and `stats` (no subcommand) produce identical output to their explicit `list`/`overview` invocations

🤖 Generated with [Claude Code](https://claude.com/claude-code)